### PR TITLE
fix: skip fee check on tx simulation

### DIFF
--- a/ante/ante.go
+++ b/ante/ante.go
@@ -100,7 +100,7 @@ func newCosmosAnteHandler(opts HandlerOptions) sdk.AnteHandler {
 		wasmkeeper.NewCountTXDecorator(opts.TxCounterStoreKey),
 		authante.NewRejectExtensionOptionsDecorator(),
 		NewMempoolFeeDecorator(opts.BypassMinFeeMsgTypes),
-		evmante.NewMinGasPriceDecorator(opts.FeeMarketKeeper, opts.EvmKeeper),
+		NewMinGasPriceDecorator(opts.FeeMarketKeeper, opts.EvmKeeper),
 		authante.NewValidateBasicDecorator(),
 		authante.NewTxTimeoutHeightDecorator(),
 		authante.NewValidateMemoDecorator(opts.AccountKeeper),


### PR DESCRIPTION
## Effects

- [x] Soft update
- [ ] Breaking change
- [ ] Chain fork related

<!-- If internal PR & if it is needed to check from a specific person, please mention. Or you may delete it  -->
## Major Reviewer
@yoosah @leeyunseon

<!-- List them -->

## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `--gas=auto` flag doesn't work

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- ante handler skip to check gas price when simulated
<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?
