### PR TITLE
fix: ignore cosmwasm account in genesis export of evm

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -109,6 +109,7 @@ import (
 	"github.com/evmos/ethermint/x/feemarket"
 	feemarketkeeper "github.com/evmos/ethermint/x/feemarket/keeper"
 	feemarkettypes "github.com/evmos/ethermint/x/feemarket/types"
+	xplaevm "github.com/xpladev/xpla/x/evm"
 
 	"github.com/strangelove-ventures/packet-forward-middleware/v2/router"
 	routerkeeper "github.com/strangelove-ventures/packet-forward-middleware/v2/router/keeper"
@@ -627,7 +628,7 @@ func NewXplaApp(
 		icaModule,
 		routerModule,
 		wasm.NewAppModule(appCodec, &app.wasmKeeper, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
-		evm.NewAppModule(app.EvmKeeper, app.AccountKeeper),
+		xplaevm.NewAppModule(app.EvmKeeper, app.AccountKeeper),
 		feemarket.NewAppModule(app.FeeMarketKeeper),
 		reward.NewAppModule(appCodec, app.RewardKeeper, app.BankKeeper, app.StakingKeeper, app.DistrKeeper),
 	)

--- a/x/evm/genesis.go
+++ b/x/evm/genesis.go
@@ -1,0 +1,46 @@
+package evm
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/ethereum/go-ethereum/common"
+
+	ethermint "github.com/evmos/ethermint/types"
+	"github.com/evmos/ethermint/x/evm/keeper"
+	"github.com/evmos/ethermint/x/evm/types"
+)
+
+// ExportGenesis exports genesis state of the EVM module
+func ExportGenesis(ctx sdk.Context, k *keeper.Keeper, ak types.AccountKeeper) *types.GenesisState {
+	var ethGenAccounts []types.GenesisAccount
+	ak.IterateAccounts(ctx, func(account authtypes.AccountI) bool {
+		// ignore cosmwasm account
+		if len(account.GetAddress()) != common.AddressLength {
+			return false
+		}
+
+		ethAccount, ok := account.(ethermint.EthAccountI)
+		if !ok {
+			// ignore non EthAccounts
+			return false
+		}
+
+		addr := ethAccount.EthAddress()
+
+		storage := k.GetAccountStorage(ctx, addr)
+
+		genAccount := types.GenesisAccount{
+			Address: addr.String(),
+			Code:    common.Bytes2Hex(k.GetCode(ctx, ethAccount.GetCodeHash())),
+			Storage: storage,
+		}
+
+		ethGenAccounts = append(ethGenAccounts, genAccount)
+		return false
+	})
+
+	return &types.GenesisState{
+		Accounts: ethGenAccounts,
+		Params:   k.GetParams(ctx),
+	}
+}

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -1,0 +1,41 @@
+package evm
+
+import (
+	"encoding/json"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/evmos/ethermint/x/evm"
+	"github.com/evmos/ethermint/x/evm/keeper"
+	"github.com/evmos/ethermint/x/evm/types"
+)
+
+var (
+	_ module.AppModule = AppModule{}
+)
+
+type AppModule struct {
+	evm.AppModule
+
+	keeper *keeper.Keeper
+	ak     types.AccountKeeper
+}
+
+// NewAppModule creates a new AppModule object
+func NewAppModule(
+	keeper *keeper.Keeper,
+	ak types.AccountKeeper) AppModule {
+	return AppModule{
+		AppModule: evm.NewAppModule(keeper, ak),
+		keeper:    keeper,
+		ak:        ak,
+	}
+}
+
+// ExportGenesis returns the exported genesis state as raw bytes for the evm
+// module.
+func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
+	gs := ExportGenesis(ctx, am.keeper, am.ak)
+	return cdc.MustMarshalJSON(gs)
+}


### PR DESCRIPTION
## Effects

- [x] Soft update
- [ ] Breaking change
- [ ] Chain fork related

<!-- If internal PR & if it is needed to check from a specific person, please mention. Or you may delete it  -->
## Major Reviewer
@yoosah 

<!-- List them -->

## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The contract address of cosmwasm is 32 bytes, but the evm module uses only 20 bytes of address when exporting.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
Cosmwasm contract that is not compatible with ethermint is removed when exporting evm module.

This patch will be v1.2.3

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
