### PR TITLE
fix: only checkTx when check gas-price

### DIFF
--- a/ante/fee.go
+++ b/ante/fee.go
@@ -47,7 +47,7 @@ func (mpd MinGasPriceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 	}
 
 	// Short-circuit if min gas price is 0 or if simulating
-	if minGasPrice.IsZero() || simulate || (mpd.bypassMinFeeMsgs(msgs) && gas <= uint64(len(msgs))*maxBypassMinFeeMsgGasUsage) {
+	if minGasPrice.IsZero() || !ctx.IsCheckTx() || simulate || (mpd.bypassMinFeeMsgs(msgs) && gas <= uint64(len(msgs))*maxBypassMinFeeMsgGasUsage) {
 		return next(ctx, tx, simulate)
 	}
 


### PR DESCRIPTION
## Effects

- [x] Soft update
- [ ] Breaking change
- [ ] Chain fork related

<!-- If internal PR & if it is needed to check from a specific person, please mention. Or you may delete it  -->
## Major Reviewer
@yoosah 

<!-- List them -->

## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Affected during block validation

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
Compare to gaia v8
```
if ctx.IsCheckTx() && !simulate && !(mfd.bypassMinFeeMsgs(msgs) && gas <= uint64(len(msgs))*maxBypassMinFeeMsgGasUsage) {
```

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
