### PR TITLE
fix: auto-set block timestamp for historical queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -192,7 +192,7 @@ replace (
 	// TODO: Simapp dependency, review removing when updating to SDK with backported update https://github.com/cosmos/cosmos-sdk/issues/13423
 	github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.22.2 // indirect
 
-	github.com/cosmos/cosmos-sdk => github.com/xpladev/cosmos-sdk v0.45.18-xpla
+	github.com/cosmos/cosmos-sdk => github.com/xpladev/cosmos-sdk v0.45.19-xpla
 
 	// enforce same SDK and IBC on all dependencies
 	github.com/cosmos/ibc-go/v4 => github.com/cosmos/ibc-go/v4 v4.5.1

--- a/go.sum
+++ b/go.sum
@@ -1046,8 +1046,8 @@ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQ
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/xpladev/cosmos-sdk v0.45.18-xpla h1:VEow1xMYMjiGvkmxQIY9msfNgInIABdioLSDs1/fytw=
-github.com/xpladev/cosmos-sdk v0.45.18-xpla/go.mod h1:3MSZtH7mYNdRrybrpw8aJi4lnjQPJgg7Suw9K4fUh/w=
+github.com/xpladev/cosmos-sdk v0.45.19-xpla h1:d7ZV4ioj+OfHiVsQZvWlyHoPmvVez/7mI0kfDyUc+wo=
+github.com/xpladev/cosmos-sdk v0.45.19-xpla/go.mod h1:3MSZtH7mYNdRrybrpw8aJi4lnjQPJgg7Suw9K4fUh/w=
 github.com/xpladev/ethermint v0.19.4-xpla h1:F7SdxazMYXhVz37u4XyyXa4nGZ0ad/g6uifZX+quAvk=
 github.com/xpladev/ethermint v0.19.4-xpla/go.mod h1:yVEHdlFKDd/ZOfkR30ZCK0yyQ3KufwmTTwvk1IYz6qY=
 github.com/xpladev/evmos/v9 v9.2.0-xpla h1:UwuEqik0RyEsxMJzlrbE9u+hfmnY1VZXQMfprJebI3U=


### PR DESCRIPTION
## Effects

- [x] Soft update
- [ ] Breaking change
- [ ] Chain fork related

<!-- If internal PR & if it is needed to check from a specific person, please mention. Or you may delete it  -->
## Major Reviewer
@leeyunseon 

<!-- List them -->

## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When querying the state of CosmWasm, timestamp is the current time.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
This change automatically set's the block time on the Context that is provided to all queries. It does this by querying for the CommitInfo for that particular version/height from the RMS.


<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
