### PR TITLE
fix: EVM legacy/new MsgEthereumTx decode

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -181,7 +181,7 @@ func NewXplaApp(
 	if err != nil {
 		panic(err)
 	}
-	interfaceRegistry = encoding.NewRegistryWithEthereumTxFallback(interfaceRegistry)
+	interfaceRegistry = encoding.NewEthereumTxCompatRegistry(interfaceRegistry)
 
 	appCodec := codec.NewProtoCodec(interfaceRegistry)
 	txConfig := encoding.NewTxConfig(appCodec, authtx.DefaultSignModes)

--- a/app/app.go
+++ b/app/app.go
@@ -73,7 +73,6 @@ import (
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
 	xplaante "github.com/xpladev/xpla/ante"
-	"github.com/xpladev/xpla/app/encoding"
 	"github.com/xpladev/xpla/app/keepers"
 	"github.com/xpladev/xpla/app/openapiconsole"
 	xplaappparams "github.com/xpladev/xpla/app/params"
@@ -181,10 +180,8 @@ func NewXplaApp(
 	if err != nil {
 		panic(err)
 	}
-	interfaceRegistry = encoding.NewEthereumTxCompatRegistry(interfaceRegistry)
-
 	appCodec := codec.NewProtoCodec(interfaceRegistry)
-	txConfig := encoding.NewTxConfig(appCodec, authtx.DefaultSignModes)
+	txConfig := authtx.NewTxConfig(appCodec, authtx.DefaultSignModes)
 
 	ethenc.RegisterLegacyAminoCodec(legacyAmino)
 	ethenc.RegisterInterfaces(interfaceRegistry)
@@ -257,7 +254,7 @@ func NewXplaApp(
 		EnabledSignModes:           enabledSignModes,
 		TextualCoinMetadataQueryFn: txmodule.NewBankKeeperCoinMetadataQueryFn(app.BankKeeper),
 	}
-	txConfig.TxConfig, err = authtx.NewTxConfigWithOptions(
+	txConfig, err = authtx.NewTxConfigWithOptions(
 		appCodec,
 		txConfigOpts,
 	)

--- a/app/app.go
+++ b/app/app.go
@@ -73,6 +73,7 @@ import (
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
 	xplaante "github.com/xpladev/xpla/ante"
+	"github.com/xpladev/xpla/app/encoding"
 	"github.com/xpladev/xpla/app/keepers"
 	"github.com/xpladev/xpla/app/openapiconsole"
 	xplaappparams "github.com/xpladev/xpla/app/params"
@@ -180,8 +181,10 @@ func NewXplaApp(
 	if err != nil {
 		panic(err)
 	}
+	interfaceRegistry = encoding.NewRegistryWithEthereumTxFallback(interfaceRegistry)
+
 	appCodec := codec.NewProtoCodec(interfaceRegistry)
-	txConfig := authtx.NewTxConfig(appCodec, authtx.DefaultSignModes)
+	txConfig := encoding.NewTxConfig(appCodec, authtx.DefaultSignModes)
 
 	ethenc.RegisterLegacyAminoCodec(legacyAmino)
 	ethenc.RegisterInterfaces(interfaceRegistry)
@@ -254,7 +257,7 @@ func NewXplaApp(
 		EnabledSignModes:           enabledSignModes,
 		TextualCoinMetadataQueryFn: txmodule.NewBankKeeperCoinMetadataQueryFn(app.BankKeeper),
 	}
-	txConfig, err = authtx.NewTxConfigWithOptions(
+	txConfig.TxConfig, err = authtx.NewTxConfigWithOptions(
 		appCodec,
 		txConfigOpts,
 	)

--- a/app/app_txconfig_test.go
+++ b/app/app_txconfig_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"math/big"
+	"testing"
+
+	"cosmossdk.io/log"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/client"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	"github.com/cosmos/gogoproto/proto"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/xpladev/xpla/app/encoding"
+	legacyevmtypes "github.com/xpladev/xpla/legacy/ethermint/x/evm/types"
+)
+
+func TestNewXplaApp_ConsensusTxConfig_IsDefault(t *testing.T) {
+	xpla := newTestApp(t)
+	_, isCompat := xpla.GetTxConfig().(*encoding.TxConfigWrapper)
+	require.False(t, isCompat)
+}
+
+func TestNewXplaApp_ConsensusTxDecoder_DoesNotNormalizeLegacyMsg(t *testing.T) {
+	xpla := newTestApp(t)
+
+	txBytes := legacyTxBytes(t, xpla.GetTxConfig(), big.NewInt(37))
+	tx, err := xpla.GetTxConfig().TxDecoder()(txBytes)
+	require.NoError(t, err)
+
+	msgs := tx.GetMsgs()
+	require.Len(t, msgs, 1)
+	require.IsType(t, &legacyevmtypes.MsgEthereumTx{}, msgs[0])
+	_, isNew := msgs[0].(*evmtypes.MsgEthereumTx)
+	require.False(t, isNew)
+}
+
+func TestNewXplaApp_ConsensusTxDecoder_RejectsCosmosTypeURLLegacyPayload(t *testing.T) {
+	xpla := newTestApp(t)
+
+	txBytes := legacyTxBytes(t, xpla.GetTxConfig(), big.NewInt(37))
+	legacyPayloadCosmosTypeURL := rewriteFirstTypeURL(t, txBytes, "/cosmos.evm.vm.v1.MsgEthereumTx")
+
+	_, err := xpla.GetTxConfig().TxDecoder()(legacyPayloadCosmosTypeURL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "TagNum: 1")
+}
+
+func newTestApp(t *testing.T) *XplaApp {
+	t.Helper()
+	home := t.TempDir()
+
+	return NewXplaApp(
+		log.NewNopLogger(),
+		dbm.NewMemDB(),
+		nil,
+		true,
+		map[int64]bool{},
+		home,
+		EmptyAppOptions{},
+		EmptyWasmOptions,
+	)
+}
+
+func legacyTxBytes(t *testing.T, txConfig client.TxConfig, v *big.Int) []byte {
+	t.Helper()
+
+	legacyMsg := newLegacyMsgEthereumTx(t, v)
+	builder := txConfig.NewTxBuilder()
+	require.NoError(t, builder.SetMsgs(legacyMsg))
+
+	txBytes, err := txConfig.TxEncoder()(builder.GetTx())
+	require.NoError(t, err)
+	return txBytes
+}
+
+func rewriteFirstTypeURL(t *testing.T, txBytes []byte, typeURL string) []byte {
+	t.Helper()
+
+	var raw txtypes.TxRaw
+	require.NoError(t, proto.Unmarshal(txBytes, &raw))
+
+	var body txtypes.TxBody
+	require.NoError(t, proto.Unmarshal(raw.BodyBytes, &body))
+	require.NotEmpty(t, body.Messages)
+
+	body.Messages[0].TypeUrl = typeURL
+	raw.BodyBytes = mustMarshalProto(t, &body)
+	return mustMarshalProto(t, &raw)
+}
+
+func newLegacyMsgEthereumTx(t *testing.T, v *big.Int) *legacyevmtypes.MsgEthereumTx {
+	t.Helper()
+
+	ethTx := ethtypes.NewTx(&ethtypes.LegacyTx{
+		Nonce:    7,
+		GasPrice: big.NewInt(1),
+		Gas:      21_000,
+		Value:    big.NewInt(42),
+		Data:     []byte{0x1, 0x2, 0x3},
+		V:        new(big.Int).Set(v),
+		R:        big.NewInt(1),
+		S:        big.NewInt(1),
+	})
+
+	txData, err := legacyevmtypes.NewTxDataFromTx(ethTx)
+	require.NoError(t, err)
+
+	txDataProto, ok := txData.(proto.Message)
+	require.True(t, ok)
+
+	anyData, err := codectypes.NewAnyWithValue(txDataProto)
+	require.NoError(t, err)
+	return &legacyevmtypes.MsgEthereumTx{Data: anyData}
+}
+
+func mustMarshalProto(t *testing.T, msg proto.Message) []byte {
+	t.Helper()
+
+	bz, err := proto.Marshal(msg)
+	require.NoError(t, err)
+	return bz
+}

--- a/app/encoding/codec.go
+++ b/app/encoding/codec.go
@@ -1,11 +1,13 @@
 package encoding
 
 import (
+	"errors"
 	"strings"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/proto"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
@@ -19,28 +21,28 @@ const (
 	accessListTxTypeURL    = "cosmos.evm.vm.v1.AccessListTx"
 )
 
-// RegistryWithEthereumTxFallback wraps an InterfaceRegistry and adds UnpackAny
-// fallback for pre-upgrade cosmos.evm.vm.v1.MsgEthereumTx (legacy payload).
-// Use this so that any code path that unpacks via the registry (e.g. x/tx decode)
-// gets the fallback.
-type RegistryWithEthereumTxFallback struct {
+// EthereumTxCompatRegistry wraps an InterfaceRegistry and adds UnpackAny/Resolve
+// behavior for pre-upgrade cosmos.evm.vm.v1.MsgEthereumTx (legacy payload).
+type EthereumTxCompatRegistry struct {
 	codectypes.InterfaceRegistry
 }
 
-// NewRegistryWithEthereumTxFallback returns a registry that delegates to inner
-// except for UnpackAny and Resolve, where it applies the EthereumTx fallback.
-func NewRegistryWithEthereumTxFallback(inner codectypes.InterfaceRegistry) *RegistryWithEthereumTxFallback {
-	return &RegistryWithEthereumTxFallback{InterfaceRegistry: inner}
+// NewEthereumTxCompatRegistry returns a registry that delegates to inner except for
+// UnpackAny and Resolve, where it applies Ethereum tx compatibility (legacy ↔ new).
+// MsgEthereumTx is resolved via inner (new type) so response display shows from/raw.
+func NewEthereumTxCompatRegistry(inner codectypes.InterfaceRegistry) *EthereumTxCompatRegistry {
+	return &EthereumTxCompatRegistry{InterfaceRegistry: inner}
 }
 
 // Resolve implements AnyResolver (used by unknownproto.RejectUnknownFields and client tx decode).
-// - For cosmos.evm.vm.v1.MsgEthereumTx we delegate to the inner registry so the new (post-upgrade)
-//   type is used; RejectUnknownFields then validates against the new schema (tag 5=from, 6=raw).
+// - For cosmos.evm.vm.v1.MsgEthereumTx we delegate to inner (new type) so that response display
+//   unmarshals correctly and shows from/raw. Legacy payloads (tag 1) fail first decode and are
+//   retried in TxDecoder with LegacyTxDecodeRegistry.
 // - For cosmos.evm.vm.v1.LegacyTx/DynamicFeeTx/AccessListTx we return legacy TxData types so
 //   the client can resolve inner Anys when decoding pre-upgrade txs (payload uses ethermint schema).
 // - All other type URLs are delegated to the inner registry as-is; the SDK stores type URLs
 //   with a leading slash (e.g. /cosmos.gov.v1beta1.MsgSubmitProposal), so we must not strip it.
-func (r *RegistryWithEthereumTxFallback) Resolve(typeURL string) (proto.Message, error) {
+func (r *EthereumTxCompatRegistry) Resolve(typeURL string) (proto.Message, error) {
 	normalized := strings.TrimPrefix(typeURL, "/")
 	switch normalized {
 	case legacyTxTypeURL:
@@ -53,33 +55,100 @@ func (r *RegistryWithEthereumTxFallback) Resolve(typeURL string) (proto.Message,
 	return r.InterfaceRegistry.Resolve(typeURL)
 }
 
-// UnpackAny implements AnyUnpacker. For cosmos.evm.vm.v1.MsgEthereumTx with
-// legacy payload, retries unmarshal as legacy MsgEthereumTx and converts to new.
-func (r *RegistryWithEthereumTxFallback) UnpackAny(any *codectypes.Any, iface interface{}) error {
-	err := r.InterfaceRegistry.UnpackAny(any, iface)
-	if err == nil {
-		return nil
+// UnpackAny implements AnyUnpacker. For cosmos.evm.vm.v1.MsgEthereumTx we try legacy
+// unmarshal first; if it succeeds and has Data (pre-upgrade payload), convert to new with from/raw.
+// For cosmos.evm.vm.v1.LegacyTx/DynamicFeeTx/AccessListTx unpacking into TxData we use legacy
+// types so UnpackInterfaces on legacy MsgEthereumTx works (inner registry may not have
+// cosmos.evm.vm.v1.* registered against ethermint TxData).
+func (r *EthereumTxCompatRegistry) UnpackAny(any *codectypes.Any, iface interface{}) error {
+	if any == nil {
+		return r.InterfaceRegistry.UnpackAny(any, iface)
 	}
-	if any == nil || !isCosmosEthereumTxTypeURL(any.TypeUrl) || !isUnknownFieldProtoErr(err) {
-		return err
-	}
-	var legacyMsg legacyevmtypes.MsgEthereumTx
-	if errLegacy := proto.Unmarshal(any.Value, &legacyMsg); errLegacy != nil {
-		return err
-	}
-	if legacyMsg.Data != nil {
-		var txData legacyevmtypes.TxData
-		if errInner := r.InterfaceRegistry.UnpackAny(legacyMsg.Data, &txData); errInner != nil {
-			return err
+	normalized := strings.TrimPrefix(any.TypeUrl, "/")
+
+	// Unpack TxData (LegacyTx/DynamicFeeTx/AccessListTx) into legacyevmtypes.TxData so legacy MsgEthereumTx.UnpackInterfaces works.
+	if ptr, ok := iface.(*legacyevmtypes.TxData); ok && ptr != nil {
+		var concrete legacyevmtypes.TxData
+		switch normalized {
+		case legacyTxTypeURL:
+			var legacy legacyevmtypes.LegacyTx
+			if err := proto.Unmarshal(any.Value, &legacy); err != nil {
+				return err
+			}
+			concrete = &legacy
+		case dynamicFeeTxTypeURL:
+			var legacy legacyevmtypes.DynamicFeeTx
+			if err := proto.Unmarshal(any.Value, &legacy); err != nil {
+				return err
+			}
+			concrete = &legacy
+		case accessListTxTypeURL:
+			var legacy legacyevmtypes.AccessListTx
+			if err := proto.Unmarshal(any.Value, &legacy); err != nil {
+				return err
+			}
+			concrete = &legacy
+		default:
+			concrete = nil
+		}
+		if concrete != nil {
+			*ptr = concrete
+			cached, err := codectypes.NewAnyWithValue(concrete.(proto.Message))
+			if err != nil {
+				return err
+			}
+			*any = *cached
+			return nil
 		}
 	}
-	newMsg := &evmtypes.MsgEthereumTx{}
-	newMsg.FromEthereumTx(legacyMsg.AsTransaction())
-	if ptr, ok := iface.(*sdk.Msg); ok {
-		*ptr = newMsg
-		return nil
+
+	if isCosmosEthereumTxTypeURL(any.TypeUrl) {
+		var legacyMsg legacyevmtypes.MsgEthereumTx
+		if errLegacy := proto.Unmarshal(any.Value, &legacyMsg); errLegacy == nil && legacyMsg.Data != nil {
+			// Pre-upgrade payload (tag 1 = data): convert to new type with from/raw populated.
+			if errUnpack := legacyMsg.UnpackInterfaces(r); errUnpack != nil {
+				return errUnpack
+			}
+			legacyTx := legacyMsg.AsTransaction()
+			newMsg := &evmtypes.MsgEthereumTx{}
+			newMsg.FromEthereumTx(legacyTx)
+			if legacyTx != nil {
+				signer := ethtypes.LatestSignerForChainID(legacyTx.ChainId())
+				_ = newMsg.FromSignedEthereumTx(legacyTx, signer)
+			}
+			if ptr, ok := iface.(*sdk.Msg); ok {
+				*ptr = newMsg
+				cached, err := codectypes.NewAnyWithValue(newMsg)
+				if err != nil {
+					return err
+				}
+				*any = *cached
+				return nil
+			}
+		}
 	}
-	return err
+	return r.InterfaceRegistry.UnpackAny(any, iface)
+}
+
+
+// legacyTxDecodeRegistry overrides only Resolve for MsgEthereumTx (returns legacy type)
+// so the fallback decode path passes RejectUnknownFields for tag 1 payloads.
+type legacyTxDecodeRegistry struct {
+	*EthereumTxCompatRegistry
+}
+
+// LegacyTxDecodeRegistry returns an InterfaceRegistry that resolves MsgEthereumTx as legacy type.
+// Use only for the fallback decode when the first decode fails on legacy (tag 1) payload.
+func LegacyTxDecodeRegistry(wrapped *EthereumTxCompatRegistry) codectypes.InterfaceRegistry {
+	return &legacyTxDecodeRegistry{EthereumTxCompatRegistry: wrapped}
+}
+
+func (r *legacyTxDecodeRegistry) Resolve(typeURL string) (proto.Message, error) {
+	normalized := strings.TrimPrefix(typeURL, "/")
+	if normalized == msgEthereumTxTypeURL {
+		return &legacyevmtypes.MsgEthereumTx{}, nil
+	}
+	return r.EthereumTxCompatRegistry.Resolve(typeURL)
 }
 
 func isCosmosEthereumTxTypeURL(typeURL string) bool {
@@ -100,34 +169,16 @@ func isUnknownFieldProtoErr(err error) bool {
 
 // IsLegacyMsgEthereumTxDecodeErr returns true when the error is from RejectUnknownFields
 // failing on a legacy MsgEthereumTx payload (tag 1 = data). Used to trigger fallback decode.
+// Checks the full error chain in case the error is wrapped.
 func IsLegacyMsgEthereumTxDecodeErr(err error) bool {
-	if err == nil {
-		return false
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		s := e.Error()
+		if strings.Contains(s, "MsgEthereumTx") &&
+			strings.Contains(s, "TagNum: 1") &&
+			isUnknownFieldProtoErr(e) {
+			return true
+		}
 	}
-	s := err.Error()
-	return strings.Contains(s, "MsgEthereumTx") &&
-		strings.Contains(s, "TagNum: 1") &&
-		isUnknownFieldProtoErr(err)
+	return false
 }
 
-// LegacyFirstRegistry wraps a RegistryWithEthereumTxFallback and overrides Resolve so that
-// cosmos.evm.vm.v1.MsgEthereumTx returns the legacy type. Used only for the fallback decode
-// path so RejectUnknownFields accepts legacy (tag 1) payloads; UnpackAny still converts to new.
-type LegacyFirstRegistry struct {
-	*RegistryWithEthereumTxFallback
-}
-
-// NewLegacyFirstRegistry returns a registry that behaves like wrapped except Resolve
-// returns the legacy MsgEthereumTx type for cosmos.evm.vm.v1.MsgEthereumTx.
-func NewLegacyFirstRegistry(wrapped *RegistryWithEthereumTxFallback) *LegacyFirstRegistry {
-	return &LegacyFirstRegistry{RegistryWithEthereumTxFallback: wrapped}
-}
-
-// Resolve returns legacy MsgEthereumTx for that type URL so RejectUnknownFields passes for legacy payloads.
-func (r *LegacyFirstRegistry) Resolve(typeURL string) (proto.Message, error) {
-	normalized := strings.TrimPrefix(typeURL, "/")
-	if normalized == msgEthereumTxTypeURL {
-		return &legacyevmtypes.MsgEthereumTx{}, nil
-	}
-	return r.RegistryWithEthereumTxFallback.Resolve(typeURL)
-}

--- a/app/encoding/codec.go
+++ b/app/encoding/codec.go
@@ -1,0 +1,133 @@
+package encoding
+
+import (
+	"strings"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
+
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+
+	legacyevmtypes "github.com/xpladev/xpla/legacy/ethermint/x/evm/types"
+)
+
+const (
+	msgEthereumTxTypeURL   = "cosmos.evm.vm.v1.MsgEthereumTx"
+	legacyTxTypeURL        = "cosmos.evm.vm.v1.LegacyTx"
+	dynamicFeeTxTypeURL    = "cosmos.evm.vm.v1.DynamicFeeTx"
+	accessListTxTypeURL    = "cosmos.evm.vm.v1.AccessListTx"
+)
+
+// RegistryWithEthereumTxFallback wraps an InterfaceRegistry and adds UnpackAny
+// fallback for pre-upgrade cosmos.evm.vm.v1.MsgEthereumTx (legacy payload).
+// Use this so that any code path that unpacks via the registry (e.g. x/tx decode)
+// gets the fallback.
+type RegistryWithEthereumTxFallback struct {
+	codectypes.InterfaceRegistry
+}
+
+// NewRegistryWithEthereumTxFallback returns a registry that delegates to inner
+// except for UnpackAny and Resolve, where it applies the EthereumTx fallback.
+func NewRegistryWithEthereumTxFallback(inner codectypes.InterfaceRegistry) *RegistryWithEthereumTxFallback {
+	return &RegistryWithEthereumTxFallback{InterfaceRegistry: inner}
+}
+
+// Resolve implements AnyResolver (used by unknownproto.RejectUnknownFields and client tx decode).
+// - For cosmos.evm.vm.v1.MsgEthereumTx we delegate to the inner registry so the new (post-upgrade)
+//   type is used; RejectUnknownFields then validates against the new schema (tag 5=from, 6=raw).
+// - For cosmos.evm.vm.v1.LegacyTx/DynamicFeeTx/AccessListTx we return legacy TxData types so
+//   the client can resolve inner Anys when decoding pre-upgrade txs (payload uses ethermint schema).
+// - All other type URLs are delegated to the inner registry as-is; the SDK stores type URLs
+//   with a leading slash (e.g. /cosmos.gov.v1beta1.MsgSubmitProposal), so we must not strip it.
+func (r *RegistryWithEthereumTxFallback) Resolve(typeURL string) (proto.Message, error) {
+	normalized := strings.TrimPrefix(typeURL, "/")
+	switch normalized {
+	case legacyTxTypeURL:
+		return &legacyevmtypes.LegacyTx{}, nil
+	case dynamicFeeTxTypeURL:
+		return &legacyevmtypes.DynamicFeeTx{}, nil
+	case accessListTxTypeURL:
+		return &legacyevmtypes.AccessListTx{}, nil
+	}
+	return r.InterfaceRegistry.Resolve(typeURL)
+}
+
+// UnpackAny implements AnyUnpacker. For cosmos.evm.vm.v1.MsgEthereumTx with
+// legacy payload, retries unmarshal as legacy MsgEthereumTx and converts to new.
+func (r *RegistryWithEthereumTxFallback) UnpackAny(any *codectypes.Any, iface interface{}) error {
+	err := r.InterfaceRegistry.UnpackAny(any, iface)
+	if err == nil {
+		return nil
+	}
+	if any == nil || !isCosmosEthereumTxTypeURL(any.TypeUrl) || !isUnknownFieldProtoErr(err) {
+		return err
+	}
+	var legacyMsg legacyevmtypes.MsgEthereumTx
+	if errLegacy := proto.Unmarshal(any.Value, &legacyMsg); errLegacy != nil {
+		return err
+	}
+	if legacyMsg.Data != nil {
+		var txData legacyevmtypes.TxData
+		if errInner := r.InterfaceRegistry.UnpackAny(legacyMsg.Data, &txData); errInner != nil {
+			return err
+		}
+	}
+	newMsg := &evmtypes.MsgEthereumTx{}
+	newMsg.FromEthereumTx(legacyMsg.AsTransaction())
+	if ptr, ok := iface.(*sdk.Msg); ok {
+		*ptr = newMsg
+		return nil
+	}
+	return err
+}
+
+func isCosmosEthereumTxTypeURL(typeURL string) bool {
+	return strings.Contains(typeURL, msgEthereumTxTypeURL)
+}
+
+func isUnknownFieldProtoErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "unknown field") ||
+		strings.Contains(s, "errUnknownField") ||
+		strings.Contains(s, "illegal tag") ||
+		strings.Contains(s, "TagNum") ||
+		strings.Contains(s, "parse error")
+}
+
+// IsLegacyMsgEthereumTxDecodeErr returns true when the error is from RejectUnknownFields
+// failing on a legacy MsgEthereumTx payload (tag 1 = data). Used to trigger fallback decode.
+func IsLegacyMsgEthereumTxDecodeErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "MsgEthereumTx") &&
+		strings.Contains(s, "TagNum: 1") &&
+		isUnknownFieldProtoErr(err)
+}
+
+// LegacyFirstRegistry wraps a RegistryWithEthereumTxFallback and overrides Resolve so that
+// cosmos.evm.vm.v1.MsgEthereumTx returns the legacy type. Used only for the fallback decode
+// path so RejectUnknownFields accepts legacy (tag 1) payloads; UnpackAny still converts to new.
+type LegacyFirstRegistry struct {
+	*RegistryWithEthereumTxFallback
+}
+
+// NewLegacyFirstRegistry returns a registry that behaves like wrapped except Resolve
+// returns the legacy MsgEthereumTx type for cosmos.evm.vm.v1.MsgEthereumTx.
+func NewLegacyFirstRegistry(wrapped *RegistryWithEthereumTxFallback) *LegacyFirstRegistry {
+	return &LegacyFirstRegistry{RegistryWithEthereumTxFallback: wrapped}
+}
+
+// Resolve returns legacy MsgEthereumTx for that type URL so RejectUnknownFields passes for legacy payloads.
+func (r *LegacyFirstRegistry) Resolve(typeURL string) (proto.Message, error) {
+	normalized := strings.TrimPrefix(typeURL, "/")
+	if normalized == msgEthereumTxTypeURL {
+		return &legacyevmtypes.MsgEthereumTx{}, nil
+	}
+	return r.RegistryWithEthereumTxFallback.Resolve(typeURL)
+}

--- a/app/encoding/codec.go
+++ b/app/encoding/codec.go
@@ -2,6 +2,7 @@ package encoding
 
 import (
 	"errors"
+	"math/big"
 	"strings"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -15,10 +16,10 @@ import (
 )
 
 const (
-	msgEthereumTxTypeURL   = "cosmos.evm.vm.v1.MsgEthereumTx"
-	legacyTxTypeURL        = "cosmos.evm.vm.v1.LegacyTx"
-	dynamicFeeTxTypeURL    = "cosmos.evm.vm.v1.DynamicFeeTx"
-	accessListTxTypeURL    = "cosmos.evm.vm.v1.AccessListTx"
+	msgEthereumTxTypeURL = "cosmos.evm.vm.v1.MsgEthereumTx"
+	legacyTxTypeURL      = "cosmos.evm.vm.v1.LegacyTx"
+	dynamicFeeTxTypeURL  = "cosmos.evm.vm.v1.DynamicFeeTx"
+	accessListTxTypeURL  = "cosmos.evm.vm.v1.AccessListTx"
 )
 
 // EthereumTxCompatRegistry wraps an InterfaceRegistry and adds UnpackAny/Resolve
@@ -35,13 +36,13 @@ func NewEthereumTxCompatRegistry(inner codectypes.InterfaceRegistry) *EthereumTx
 }
 
 // Resolve implements AnyResolver (used by unknownproto.RejectUnknownFields and client tx decode).
-// - For cosmos.evm.vm.v1.MsgEthereumTx we delegate to inner (new type) so that response display
-//   unmarshals correctly and shows from/raw. Legacy payloads (tag 1) fail first decode and are
-//   retried in TxDecoder with LegacyTxDecodeRegistry.
-// - For cosmos.evm.vm.v1.LegacyTx/DynamicFeeTx/AccessListTx we return legacy TxData types so
-//   the client can resolve inner Anys when decoding pre-upgrade txs (payload uses ethermint schema).
-// - All other type URLs are delegated to the inner registry as-is; the SDK stores type URLs
-//   with a leading slash (e.g. /cosmos.gov.v1beta1.MsgSubmitProposal), so we must not strip it.
+//   - For cosmos.evm.vm.v1.MsgEthereumTx we delegate to inner (new type) so that response display
+//     unmarshals correctly and shows from/raw. Legacy payloads (tag 1) fail first decode and are
+//     retried in TxDecoder with LegacyTxDecodeRegistry.
+//   - For cosmos.evm.vm.v1.LegacyTx/DynamicFeeTx/AccessListTx we return legacy TxData types so
+//     the client can resolve inner Anys when decoding pre-upgrade txs (payload uses ethermint schema).
+//   - All other type URLs are delegated to the inner registry as-is; the SDK stores type URLs
+//     with a leading slash (e.g. /cosmos.gov.v1beta1.MsgSubmitProposal), so we must not strip it.
 func (r *EthereumTxCompatRegistry) Resolve(typeURL string) (proto.Message, error) {
 	normalized := strings.TrimPrefix(typeURL, "/")
 	switch normalized {
@@ -113,7 +114,7 @@ func (r *EthereumTxCompatRegistry) UnpackAny(any *codectypes.Any, iface interfac
 			newMsg := &evmtypes.MsgEthereumTx{}
 			newMsg.FromEthereumTx(legacyTx)
 			if legacyTx != nil {
-				signer := ethtypes.LatestSignerForChainID(legacyTx.ChainId())
+				signer := legacySigner(legacyTx.ChainId())
 				_ = newMsg.FromSignedEthereumTx(legacyTx, signer)
 			}
 			if ptr, ok := iface.(*sdk.Msg); ok {
@@ -129,7 +130,6 @@ func (r *EthereumTxCompatRegistry) UnpackAny(any *codectypes.Any, iface interfac
 	}
 	return r.InterfaceRegistry.UnpackAny(any, iface)
 }
-
 
 // legacyTxDecodeRegistry overrides only Resolve for MsgEthereumTx (returns legacy type)
 // so the fallback decode path passes RejectUnknownFields for tag 1 payloads.
@@ -153,6 +153,14 @@ func (r *legacyTxDecodeRegistry) Resolve(typeURL string) (proto.Message, error) 
 
 func isCosmosEthereumTxTypeURL(typeURL string) bool {
 	return strings.Contains(typeURL, msgEthereumTxTypeURL)
+}
+
+// legacySigner chooses a signer that won't panic for pre-EIP-155 signatures.
+func legacySigner(chainID *big.Int) ethtypes.Signer {
+	if chainID != nil && chainID.Sign() > 0 {
+		return ethtypes.LatestSignerForChainID(chainID)
+	}
+	return ethtypes.HomesteadSigner{}
 }
 
 func isUnknownFieldProtoErr(err error) bool {
@@ -181,4 +189,3 @@ func IsLegacyMsgEthereumTxDecodeErr(err error) bool {
 	}
 	return false
 }
-

--- a/app/encoding/tx.go
+++ b/app/encoding/tx.go
@@ -5,8 +5,15 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+
 	txsigning "cosmossdk.io/x/tx/signing"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	legacyevmtypes "github.com/xpladev/xpla/legacy/ethermint/x/evm/types"
 )
 
 var _ client.TxConfig = &TxConfigWrapper{}
@@ -44,8 +51,84 @@ func (w *TxConfigWrapper) TxDecoder() sdk.TxDecoder {
 		if err != nil {
 			return nil, err
 		}
+		return w.normalizeLegacyEthereumMsgs(tx)
+	}
+}
+
+func (w *TxConfigWrapper) normalizeLegacyEthereumMsgs(tx sdk.Tx) (sdk.Tx, error) {
+	msgs := tx.GetMsgs()
+	newMsgs := make([]sdk.Msg, len(msgs))
+	isModified := false
+
+	for i, msg := range msgs {
+		if legacyMsg, ok := msg.(*legacyevmtypes.MsgEthereumTx); ok {
+			legacyTx := legacyMsg.AsTransaction()
+			newMsg := &evmtypes.MsgEthereumTx{}
+			newMsg.FromEthereumTx(legacyTx)
+			if legacyTx != nil && legacyTx.ChainId() != nil && legacyTx.ChainId().Sign() > 0 {
+				signer := ethtypes.LatestSignerForChainID(legacyTx.ChainId())
+				_ = newMsg.FromSignedEthereumTx(legacyTx, signer)
+			}
+			newMsgs[i] = newMsg
+			isModified = true
+			continue
+		}
+		newMsgs[i] = msg
+	}
+
+	if !isModified {
 		return tx, nil
 	}
+
+	txBuilder := w.NewTxBuilder()
+
+	if feeTx, ok := tx.(sdk.FeeTx); ok {
+		txBuilder.SetGasLimit(feeTx.GetGas())
+		txBuilder.SetFeeAmount(feeTx.GetFee())
+		txBuilder.SetFeePayer(feeTx.FeePayer())
+		txBuilder.SetFeeGranter(feeTx.FeeGranter())
+	}
+
+	if memoTx, ok := tx.(sdk.TxWithMemo); ok {
+		txBuilder.SetMemo(memoTx.GetMemo())
+	}
+
+	if tsTx, ok := tx.(sdk.TxWithTimeoutTimeStamp); ok {
+		txBuilder.SetTimeoutTimestamp(tsTx.GetTimeoutTimeStamp())
+	}
+
+	if thTx, ok := tx.(sdk.TxWithTimeoutHeight); ok {
+		txBuilder.SetTimeoutHeight(thTx.GetTimeoutHeight())
+	}
+
+	if uoTx, ok := tx.(sdk.TxWithUnordered); ok {
+		txBuilder.SetUnordered(uoTx.GetUnordered())
+	}
+
+	if err := txBuilder.SetMsgs(newMsgs...); err != nil {
+		return nil, err
+	}
+
+	if sigTx, ok := tx.(authsigning.SigVerifiableTx); ok {
+		sigs, err := sigTx.GetSignaturesV2()
+		if err != nil {
+			return nil, err
+		}
+		if len(sigs) > 0 {
+			if err := txBuilder.SetSignatures(sigs...); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if extTx, ok := tx.(authante.HasExtensionOptionsTx); ok {
+		if extTxBuilder, ok := txBuilder.(authtx.ExtensionOptionsTxBuilder); ok {
+			extTxBuilder.SetExtensionOptions(extTx.GetExtensionOptions()...)
+			extTxBuilder.SetNonCriticalExtensionOptions(extTx.GetNonCriticalExtensionOptions()...)
+		}
+	}
+
+	return txBuilder.GetTx(), nil
 }
 
 // TxEncoder delegates to the inner TxConfig

--- a/app/encoding/tx.go
+++ b/app/encoding/tx.go
@@ -8,6 +8,7 @@ import (
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+	txsigning "cosmossdk.io/x/tx/signing"
 
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
@@ -20,22 +21,40 @@ var _ client.TxConfig = &TxConfigWrapper{}
 func NewTxConfig(cdc codec.Codec, sigModes []signingtypes.SignMode) *TxConfigWrapper {
 	return &TxConfigWrapper{
 		TxConfig: authtx.NewTxConfig(cdc, sigModes),
+		Codec:    cdc,
 	}
 }
 
-// TxConfigWrapper wraps the default TxConfig and provides a custom TxDecoder
+// TxConfigWrapper wraps the default TxConfig and provides a custom TxDecoder.
+// TxConfig is a settable field so that the inner config can be replaced (e.g. with NewTxConfigWithOptions).
+// Codec is used for the legacy MsgEthereumTx fallback decode path.
 type TxConfigWrapper struct {
-	client.TxConfig
+	TxConfig client.TxConfig
+	Codec    codec.Codec
 }
 
-// The TxDecoder wraps the default TxDecoder to convert the legacy ethermint MsgEthereumTx to the new cosmos evmtypes MsgEthereumTx
+// TxDecoder returns a decoder that converts legacy ethermint MsgEthereumTx to the new cosmos evmtypes MsgEthereumTx
 func (w *TxConfigWrapper) TxDecoder() sdk.TxDecoder {
 	defaultDecoder := w.TxConfig.TxDecoder()
 
 	return func(txBytes []byte) (sdk.Tx, error) {
 		tx, err := defaultDecoder(txBytes)
 		if err != nil {
-			return nil, err
+			// Fallback: legacy MsgEthereumTx (tag 1) fails RejectUnknownFields when Resolve returns new type.
+			// Retry with a registry that resolves MsgEthereumTx to legacy so body validation passes.
+			if w.Codec != nil && IsLegacyMsgEthereumTxDecodeErr(err) {
+				if wrapped, ok := w.Codec.InterfaceRegistry().(*RegistryWithEthereumTxFallback); ok {
+					legacyFirst := NewLegacyFirstRegistry(wrapped)
+					legacyCodec := codec.NewProtoCodec(legacyFirst)
+					legacyDecoder := authtx.DefaultTxDecoder(legacyCodec)
+					if fallbackTx, fallbackErr := legacyDecoder(txBytes); fallbackErr == nil {
+						tx, err = fallbackTx, nil
+					}
+				}
+			}
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		msgs := tx.GetMsgs()
@@ -106,4 +125,49 @@ func (w *TxConfigWrapper) TxDecoder() sdk.TxDecoder {
 
 		return tx, nil
 	}
+}
+
+// TxEncoder delegates to the inner TxConfig
+func (w *TxConfigWrapper) TxEncoder() sdk.TxEncoder {
+	return w.TxConfig.TxEncoder()
+}
+
+// NewTxBuilder delegates to the inner TxConfig
+func (w *TxConfigWrapper) NewTxBuilder() client.TxBuilder {
+	return w.TxConfig.NewTxBuilder()
+}
+
+// SignModeHandler delegates to the inner TxConfig
+func (w *TxConfigWrapper) SignModeHandler() *txsigning.HandlerMap {
+	return w.TxConfig.SignModeHandler()
+}
+
+// TxJSONEncoder delegates to the inner TxConfig
+func (w *TxConfigWrapper) TxJSONEncoder() sdk.TxEncoder {
+	return w.TxConfig.TxJSONEncoder()
+}
+
+// TxJSONDecoder delegates to the inner TxConfig
+func (w *TxConfigWrapper) TxJSONDecoder() sdk.TxDecoder {
+	return w.TxConfig.TxJSONDecoder()
+}
+
+// MarshalSignatureJSON delegates to the inner TxConfig
+func (w *TxConfigWrapper) MarshalSignatureJSON(sigs []signingtypes.SignatureV2) ([]byte, error) {
+	return w.TxConfig.MarshalSignatureJSON(sigs)
+}
+
+// UnmarshalSignatureJSON delegates to the inner TxConfig
+func (w *TxConfigWrapper) UnmarshalSignatureJSON(b []byte) ([]signingtypes.SignatureV2, error) {
+	return w.TxConfig.UnmarshalSignatureJSON(b)
+}
+
+// WrapTxBuilder delegates to the inner TxConfig
+func (w *TxConfigWrapper) WrapTxBuilder(tx sdk.Tx) (client.TxBuilder, error) {
+	return w.TxConfig.WrapTxBuilder(tx)
+}
+
+// SigningContext delegates to the inner TxConfig
+func (w *TxConfigWrapper) SigningContext() *txsigning.Context {
+	return w.TxConfig.SigningContext()
 }

--- a/app/encoding/tx.go
+++ b/app/encoding/tx.go
@@ -11,7 +11,6 @@ import (
 
 	txsigning "cosmossdk.io/x/tx/signing"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	legacyevmtypes "github.com/xpladev/xpla/legacy/ethermint/x/evm/types"
 )
@@ -40,12 +39,11 @@ func (w *TxConfigWrapper) TxDecoder() sdk.TxDecoder {
 
 	return func(txBytes []byte) (sdk.Tx, error) {
 		tx, err := defaultDecoder(txBytes)
-		if err != nil && w.Codec != nil {
-			if wrapped, ok := w.Codec.InterfaceRegistry().(*EthereumTxCompatRegistry); ok && IsLegacyMsgEthereumTxDecodeErr(err) {
-				fallbackDecoder := authtx.DefaultTxDecoder(codec.NewProtoCodec(LegacyTxDecodeRegistry(wrapped)))
-				if fallbackTx, fallbackErr := fallbackDecoder(txBytes); fallbackErr == nil {
-					tx, err = fallbackTx, nil
-				}
+		if err != nil && w.Codec != nil && IsLegacyMsgEthereumTxDecodeErr(err) {
+			wrapped := NewEthereumTxCompatRegistry(w.Codec.InterfaceRegistry())
+			fallbackDecoder := authtx.DefaultTxDecoder(codec.NewProtoCodec(LegacyTxDecodeRegistry(wrapped)))
+			if fallbackTx, fallbackErr := fallbackDecoder(txBytes); fallbackErr == nil {
+				tx, err = fallbackTx, nil
 			}
 		}
 		if err != nil {
@@ -65,8 +63,8 @@ func (w *TxConfigWrapper) normalizeLegacyEthereumMsgs(tx sdk.Tx) (sdk.Tx, error)
 			legacyTx := legacyMsg.AsTransaction()
 			newMsg := &evmtypes.MsgEthereumTx{}
 			newMsg.FromEthereumTx(legacyTx)
-			if legacyTx != nil && legacyTx.ChainId() != nil && legacyTx.ChainId().Sign() > 0 {
-				signer := ethtypes.LatestSignerForChainID(legacyTx.ChainId())
+			if legacyTx != nil {
+				signer := legacySigner(legacyTx.ChainId())
 				_ = newMsg.FromSignedEthereumTx(legacyTx, signer)
 			}
 			newMsgs[i] = newMsg

--- a/app/encoding/tx.go
+++ b/app/encoding/tx.go
@@ -5,14 +5,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
-	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
-	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	txsigning "cosmossdk.io/x/tx/signing"
-
-	evmtypes "github.com/cosmos/evm/x/vm/types"
-
-	legacyevmtypes "github.com/xpladev/xpla/legacy/ethermint/x/evm/types"
 )
 
 var _ client.TxConfig = &TxConfigWrapper{}
@@ -33,96 +27,23 @@ type TxConfigWrapper struct {
 	Codec    codec.Codec
 }
 
-// TxDecoder returns a decoder that converts legacy ethermint MsgEthereumTx to the new cosmos evmtypes MsgEthereumTx
+// TxDecoder returns a decoder that retries with LegacyTxDecodeRegistry when the first decode fails on legacy MsgEthereumTx (tag 1).
 func (w *TxConfigWrapper) TxDecoder() sdk.TxDecoder {
 	defaultDecoder := w.TxConfig.TxDecoder()
 
 	return func(txBytes []byte) (sdk.Tx, error) {
 		tx, err := defaultDecoder(txBytes)
+		if err != nil && w.Codec != nil {
+			if wrapped, ok := w.Codec.InterfaceRegistry().(*EthereumTxCompatRegistry); ok && IsLegacyMsgEthereumTxDecodeErr(err) {
+				fallbackDecoder := authtx.DefaultTxDecoder(codec.NewProtoCodec(LegacyTxDecodeRegistry(wrapped)))
+				if fallbackTx, fallbackErr := fallbackDecoder(txBytes); fallbackErr == nil {
+					tx, err = fallbackTx, nil
+				}
+			}
+		}
 		if err != nil {
-			// Fallback: legacy MsgEthereumTx (tag 1) fails RejectUnknownFields when Resolve returns new type.
-			// Retry with a registry that resolves MsgEthereumTx to legacy so body validation passes.
-			if w.Codec != nil && IsLegacyMsgEthereumTxDecodeErr(err) {
-				if wrapped, ok := w.Codec.InterfaceRegistry().(*RegistryWithEthereumTxFallback); ok {
-					legacyFirst := NewLegacyFirstRegistry(wrapped)
-					legacyCodec := codec.NewProtoCodec(legacyFirst)
-					legacyDecoder := authtx.DefaultTxDecoder(legacyCodec)
-					if fallbackTx, fallbackErr := legacyDecoder(txBytes); fallbackErr == nil {
-						tx, err = fallbackTx, nil
-					}
-				}
-			}
-			if err != nil {
-				return nil, err
-			}
+			return nil, err
 		}
-
-		msgs := tx.GetMsgs()
-		newMsgs := make([]sdk.Msg, len(msgs))
-		isModified := false
-
-		for i, msg := range msgs {
-			// convert legacy ethermint message into the evmtypes message
-			if legacyMsg, ok := msg.(*legacyevmtypes.MsgEthereumTx); ok {
-				legacyTx := legacyMsg.AsTransaction()
-				newMsg := &evmtypes.MsgEthereumTx{}
-				newMsg.FromEthereumTx(legacyTx)
-				newMsgs[i] = newMsg
-				isModified = true
-			} else {
-				newMsgs[i] = msg
-			}
-		}
-
-		// if a conversion occurred, the transaction is rebuilt
-		if isModified {
-			txBuilder := w.NewTxBuilder()
-
-			if feeTx, ok := tx.(sdk.FeeTx); ok {
-				txBuilder.SetGasLimit(feeTx.GetGas())
-				txBuilder.SetFeeAmount(feeTx.GetFee())
-				txBuilder.SetFeePayer(feeTx.FeePayer())
-				txBuilder.SetFeeGranter(feeTx.FeeGranter())
-			}
-
-			if memoTx, ok := tx.(sdk.TxWithMemo); ok {
-				txBuilder.SetMemo(memoTx.GetMemo())
-			}
-
-			if tsTx, ok := tx.(sdk.TxWithTimeoutTimeStamp); ok {
-				txBuilder.SetTimeoutTimestamp(tsTx.GetTimeoutTimeStamp())
-			}
-
-			if thTx, ok := tx.(sdk.TxWithTimeoutHeight); ok {
-				txBuilder.SetTimeoutHeight(thTx.GetTimeoutHeight())
-			}
-
-			if uoTx, ok := tx.(sdk.TxWithUnordered); ok {
-				txBuilder.SetUnordered(uoTx.GetUnordered())
-			}
-
-			if sigTx, ok := tx.(authsigning.SigVerifiableTx); ok {
-				sigs, err := sigTx.GetSignaturesV2()
-				if err != nil {
-					return nil, err
-				}
-				txBuilder.SetSignatures(sigs...)
-			}
-
-			if extTx, ok := tx.(authante.HasExtensionOptionsTx); ok {
-				if extTxBuilder, ok := txBuilder.(authtx.ExtensionOptionsTxBuilder); ok {
-					extTxBuilder.SetExtensionOptions(extTx.GetExtensionOptions()...)
-					extTxBuilder.SetNonCriticalExtensionOptions(extTx.GetNonCriticalExtensionOptions()...)
-				}
-			}
-
-			if err := txBuilder.SetMsgs(newMsgs...); err != nil {
-				return nil, err
-			}
-
-			return txBuilder.GetTx(), nil
-		}
-
 		return tx, nil
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -282,7 +282,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/xpladev/cosmos-sdk v0.53.4-768cb210-xpla
 
 	// xpla features
-	github.com/cosmos/evm => github.com/xpladev/evm v0.5.1-xpla.1
+	github.com/cosmos/evm => github.com/xpladev/evm v0.5.1-xpla.2
 
 	// xpla features
 	github.com/cosmos/ledger-cosmos-go => github.com/xpladev/ledger-cosmos-go v0.16.0-xpla.1

--- a/go.sum
+++ b/go.sum
@@ -1709,8 +1709,8 @@ github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xpladev/cosmos-sdk v0.53.4-768cb210-xpla h1:wq3GGicPnujpzS+NcuVh97PFEmUP8vXZPbSL0GR2QQg=
 github.com/xpladev/cosmos-sdk v0.53.4-768cb210-xpla/go.mod h1:nifazrMGFjpmOuaVIZBQ8akQc160imzySYFEA8A7tus=
-github.com/xpladev/evm v0.5.1-xpla.1 h1:oM6YOgSEYalBPoswW80vickPusYzqV7JMoJ1f8bTDOM=
-github.com/xpladev/evm v0.5.1-xpla.1/go.mod h1:AiKOtGMt539qICNH2Kdy+iw9yK3rlcU6MWet3+g8sWs=
+github.com/xpladev/evm v0.5.1-xpla.2 h1:QMmuwpbjuBg1TZ/XdR5U79hC9f0Rx0Yk98uxdbzj0GU=
+github.com/xpladev/evm v0.5.1-xpla.2/go.mod h1:AiKOtGMt539qICNH2Kdy+iw9yK3rlcU6MWet3+g8sWs=
 github.com/xpladev/go-ethereum v1.16.2-xpla-evm h1:kelMWZ91b/rfeMnIkk57w4rPSPm9wHlChFocIU1oIdU=
 github.com/xpladev/go-ethereum v1.16.2-xpla-evm/go.mod h1:X5CIOyo8SuK1Q5GnaEizQVLHT/DfsiGWuNeVdQcEMNA=
 github.com/xpladev/ledger-cosmos-go v0.16.0-xpla.1 h1:0sIH6/K1pE+75byzNDE3BoQ9gdl3KCfjeaAS6DSjnUg=


### PR DESCRIPTION
## Effects

- [ ] Soft update
- [ ] Breaking change
- [ ] Chain fork related

<!-- If internal PR & if it is needed to check from a specific person, please mention. Or you may delete it  -->
## Major Reviewer
@yoosah 

<!-- List them -->

## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The `MsgEthereumTx` proto definition changed with the EVM module upgrade (tag 1 `data` → tag 5/6, etc.).
- Default decoding uses the new type, so legacy (tag 1) payloads fail in `RejectUnknownFields`.
- If we resolve to the legacy type instead, response Anys that contain new-format bytes are unmarshaled into the legacy type, so tag 5/6 are ignored and `from` / `raw` appear empty.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
After the EVM module upgrade, **existing ethermint-format** `cosmos.evm.vm.v1.MsgEthereumTx` (proto tag 1 = `data`) could not be decoded correctly—either decode failed or the decoded message had empty fields. This change restores compatibility so that both **legacy** (tag 1) and **new** (tag 5/6) `MsgEthereumTx` payloads decode successfully, and **Msg fields are populated**: **`from` and `raw` (data)** (and related fields) are filled instead of empty.
<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
