### PR TITLE
test: optimize e2e image build

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,15 +13,21 @@ This module is basically for the automated end-to-end test. But if you want to e
 # 1. From the repo root, move to the tests/e2e, and execute docker compose
 cd tests/e2e
 docker compose up -d
+# (or force rebuild once)
+# docker compose up --build -d
+
+# Note: e2e compose builds the shared image `xpla-localnet-e2e:latest` once
+# and all validator/volunteer nodes reuse that same image.
+# It also uses local image only (`pull_policy: never`) to avoid registry pull noise.
 
 # 2. Wait for building. Once done without error, you may check the nodes running
 docker ps
 
 #CONTAINER ID   IMAGE                    COMMAND                  CREATED          STATUS          PORTS                                                                             NAMES
-#648b7146ce8c   e2e-node1   "sh -c 'MONIKER=vali…"   44 minutes ago   Up 44 minutes   0.0.0.0:8545->8545/tcp, 0.0.0.0:9090->9090/tcp, 0.0.0.0:26656->26656/tcp          xpla-localnet-validator1
-#97279d567135   e2e-node2   "sh -c 'MONIKER=vali…"   44 minutes ago   Up 44 minutes   8545/tcp, 9090/tcp, 0.0.0.0:9100->9100/tcp, 26656/tcp, 0.0.0.0:26666->26666/tcp   xpla-localnet-validator2
-#f604f68c3f82   e2e-node3   "sh -c 'MONIKER=vali…"   44 minutes ago   Up 44 minutes   8545/tcp, 9090/tcp, 0.0.0.0:9110->9110/tcp, 26656/tcp, 0.0.0.0:26676->26676/tcp   xpla-localnet-validator3
-#c3d0d9daefd2   e2e-node4   "sh -c 'MONIKER=vali…"   44 minutes ago   Up 44 minutes   8545/tcp, 9090/tcp, 0.0.0.0:9120->9120/tcp, 26656/tcp, 0.0.0.0:26686->26686/tcp   xpla-localnet-validator4
+#648b7146ce8c   xpla-localnet-e2e:latest   "sh -c 'MONIKER=vali…"   44 minutes ago   Up 44 minutes   0.0.0.0:8545->8545/tcp, 0.0.0.0:9090->9090/tcp, 0.0.0.0:26656->26656/tcp          xpla-localnet-validator1
+#97279d567135   xpla-localnet-e2e:latest   "sh -c 'MONIKER=vali…"   44 minutes ago   Up 44 minutes   8545/tcp, 9090/tcp, 0.0.0.0:9100->9100/tcp, 26656/tcp, 0.0.0.0:26666->26666/tcp   xpla-localnet-validator2
+#f604f68c3f82   xpla-localnet-e2e:latest   "sh -c 'MONIKER=vali…"   44 minutes ago   Up 44 minutes   8545/tcp, 9090/tcp, 0.0.0.0:9110->9110/tcp, 26656/tcp, 0.0.0.0:26676->26676/tcp   xpla-localnet-validator3
+#c3d0d9daefd2   xpla-localnet-e2e:latest   "sh -c 'MONIKER=vali…"   44 minutes ago   Up 44 minutes   8545/tcp, 9090/tcp, 0.0.0.0:9120->9120/tcp, 26656/tcp, 0.0.0.0:26686->26686/tcp   xpla-localnet-validator4
 
 # 3. Execute tests
 go test

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.7"
 services:
   node1:
     container_name: xpla-localnet-validator1
+    image: xpla-localnet-e2e:latest
+    pull_policy: never
 
     build:
       context: ../../.
@@ -24,16 +26,14 @@ services:
 
   node2:
     container_name: xpla-localnet-validator2
+    image: xpla-localnet-e2e:latest
+    pull_policy: never
 
     volumes:
       - ~/genesis:/genesis:ro
 
     depends_on:
       - node1
-
-    build:
-      context: ../../.
-      target: runtime
 
     ports:
       - "18555:8545"
@@ -48,16 +48,14 @@ services:
 
   node3:
     container_name: xpla-localnet-validator3
+    image: xpla-localnet-e2e:latest
+    pull_policy: never
 
     volumes:
       - ~/genesis:/genesis:ro
 
     depends_on:
       - node1
-
-    build:
-      context: ../../.
-      target: runtime
 
     ports:
       - "18565:8545"
@@ -72,16 +70,14 @@ services:
 
   node4:
     container_name: xpla-localnet-validator4
+    image: xpla-localnet-e2e:latest
+    pull_policy: never
 
     volumes:
       - ~/genesis:/genesis:ro
 
     depends_on:
       - node1
-
-    build:
-      context: ../../.
-      target: runtime
 
     ports:
       - "18575:8545"
@@ -96,16 +92,14 @@ services:
 
   node5:
     container_name: xpla-localnet-validator5
+    image: xpla-localnet-e2e:latest
+    pull_policy: never
 
     volumes:
       - ~/genesis:/genesis:ro
 
     depends_on:
       - node1
-
-    build:
-      context: ../../.
-      target: runtime
 
     ports:
       - "18585:8545"
@@ -120,16 +114,14 @@ services:
 
   node-volunteer-1:
     container_name: xpla-localnet-volunteer1
+    image: xpla-localnet-e2e:latest
+    pull_policy: never
 
     volumes:
       - ~/genesis:/genesis:ro
 
     depends_on:
       - node1
-
-    build:
-      context: ../../.
-      target: runtime
 
     ports:
       - "18595:8545"
@@ -144,16 +136,14 @@ services:
 
   node-volunteer-2:
     container_name: xpla-localnet-volunteer2
+    image: xpla-localnet-e2e:latest
+    pull_policy: never
 
     volumes:
       - ~/genesis:/genesis:ro
 
     depends_on:
       - node1
-
-    build:
-      context: ../../.
-      target: runtime
 
     ports:
       - "18605:8545"
@@ -168,16 +158,14 @@ services:
 
   node-volunteer-3:
     container_name: xpla-localnet-volunteer3
+    image: xpla-localnet-e2e:latest
+    pull_policy: never
 
     volumes:
       - ~/genesis:/genesis:ro
 
     depends_on:
       - node1
-
-    build:
-      context: ../../.
-      target: runtime
 
     ports:
       - "18615:8545"


### PR DESCRIPTION
## Summary
Update tests/e2e Docker Compose setup so all E2E nodes reuse a single shared image.
Now e2e compose builds a shared image `xpla-localnet-e2e:latest` once and all validator/volunteer nodes reuse the same image. It also uses local image only (`pull_policy: never`) to avoid registry pull noise.

## Effects

- [ ] Soft update
- [ ] Breaking change
- [ ] Chain fork related

<!-- If internal PR & if it is needed to check from a specific person, please mention. Or you may delete it  -->
## Major Reviewer

<!-- List them -->

## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
