### PR TITLE
fix: initialize EVM mempool client context for rebroadcast

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -286,7 +286,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/xpladev/cosmos-sdk v0.53.6-xpla-2
 
 	// xpla features
-	github.com/cosmos/evm => github.com/xpladev/evm v0.6.0-xpla.1
+	github.com/cosmos/evm => github.com/xpladev/evm v0.6.0-xpla.2
 
 	// xpla features
 	github.com/cosmos/ledger-cosmos-go => github.com/xpladev/ledger-cosmos-go v0.16.0-xpla.1

--- a/go.sum
+++ b/go.sum
@@ -1726,8 +1726,8 @@ github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xpladev/cosmos-sdk v0.53.6-xpla-2 h1:6/ffVxMEIGJGqsDVF8fyRuVIaZ78Ftuo3iZvHAvAlcU=
 github.com/xpladev/cosmos-sdk v0.53.6-xpla-2/go.mod h1:N6YuprhAabInbT3YGumGDKONbvPX5dNro7RjHvkQoKE=
-github.com/xpladev/evm v0.6.0-xpla.1 h1:2SpBrz/fbU8FfnAL6vAhzpPTpu4FafSyiEv7EPCBZcs=
-github.com/xpladev/evm v0.6.0-xpla.1/go.mod h1:QnaJDtxqon2mywiYqxM8VwW8FKeFazi0au0qzVpFAG8=
+github.com/xpladev/evm v0.6.0-xpla.2 h1:aoz5qAZYm1u2OJuO25CtwNKbQmFW8njBNQ2sP5PeRd4=
+github.com/xpladev/evm v0.6.0-xpla.2/go.mod h1:QnaJDtxqon2mywiYqxM8VwW8FKeFazi0au0qzVpFAG8=
 github.com/xpladev/go-ethereum v1.16.2-xpla-evm h1:kelMWZ91b/rfeMnIkk57w4rPSPm9wHlChFocIU1oIdU=
 github.com/xpladev/go-ethereum v1.16.2-xpla-evm/go.mod h1:X5CIOyo8SuK1Q5GnaEizQVLHT/DfsiGWuNeVdQcEMNA=
 github.com/xpladev/ledger-cosmos-go v0.16.0-xpla.1 h1:0sIH6/K1pE+75byzNDE3BoQ9gdl3KCfjeaAS6DSjnUg=


### PR DESCRIPTION
## Effects

- [x] Soft update
- [ ] Breaking change
- [ ] Chain fork related

<!-- If internal PR & if it is needed to check from a specific person, please mention. Or you may delete it  -->
## Major Reviewer
@yoosah 
<!-- List them -->

## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A panic occurs during a mempool broadcast due to a clientContext initialization issue on a node where lcd, grpc, and epm-rpc are all disabled.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
