### PR TITLE
fix: remove legacy PFM parameters during v11 upgrade migration

### DIFF
--- a/app/upgrades/v1_11/upgrades.go
+++ b/app/upgrades/v1_11/upgrades.go
@@ -7,18 +7,27 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	pfmtypes "github.com/cosmos/ibc-go/v11/modules/apps/packet-forward-middleware/types"
 
 	"github.com/xpladev/xpla/app/keepers"
 )
 
+// legacyPFMParamsKey was used by PFM consensus version 2 to store module
+// parameters. PFM v10 removed the parameters but left the value in the module
+// store, while the v11 migration interprets every store value as an in-flight
+// packet.
+var legacyPFMParamsKey = []byte{0x00}
+
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
-	_ *keepers.AppKeepers,
+	appKeepers *keepers.AppKeepers,
 	_ codec.BinaryCodec,
 ) upgradetypes.UpgradeHandler {
 	return func(c context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		ctx := sdk.UnwrapSDKContext(c)
+
+		removeLegacyPFMParams(ctx, appKeepers)
 
 		// This runs the ibc-go v11.2 in-place migrations on the legacy ibc-apps
 		// stores: PFM 3->4 and rate-limiting 1->2. The PFM migration rejects
@@ -26,4 +35,14 @@ func CreateUpgradeHandler(
 		// semantics during the upgrade.
 		return mm.RunMigrations(ctx, configurator, fromVM)
 	}
+}
+
+func removeLegacyPFMParams(ctx sdk.Context, appKeepers *keepers.AppKeepers) {
+	store := ctx.KVStore(appKeepers.GetKVStoreKey()[pfmtypes.StoreKey])
+	if !store.Has(legacyPFMParamsKey) {
+		return
+	}
+
+	store.Delete(legacyPFMParamsKey)
+	ctx.Logger().Info("removed legacy PFM params from module store", "module", pfmtypes.ModuleName)
 }

--- a/app/upgrades/v1_11/upgrades_test.go
+++ b/app/upgrades/v1_11/upgrades_test.go
@@ -35,6 +35,11 @@ func TestUpgradeHandlerMigratesIBCMiddlewareState(t *testing.T) {
 	xpla, ctx := setupUpgradeState(t)
 
 	pfmStore := ctx.KVStore(xpla.GetKey(pfmtypes.StoreKey))
+	legacyParamsKey := []byte{0x00}
+	// PFM v7 encoded its default fee percentage as protobuf field 1 containing
+	// the string "0". The v11 migration otherwise decodes this value as an
+	// in-flight packet with an empty timeout height and panics.
+	pfmStore.Set(legacyParamsKey, []byte{0x0a, 0x01, 0x30})
 	pfmKey := setLegacyPFMPacket(t, pfmStore, false)
 
 	rateLimitStore := ctx.KVStore(xpla.GetKey(ratelimittypes.StoreKey))
@@ -59,6 +64,7 @@ func TestUpgradeHandlerMigratesIBCMiddlewareState(t *testing.T) {
 	require.NoError(t, migratedPacket.Unmarshal(pfmStore.Get(pfmKey)))
 	require.Equal(t, "channel-1", migratedPacket.PacketSrcChannelId)
 	require.Equal(t, "transfer", migratedPacket.PacketSrcPortId)
+	require.Nil(t, pfmStore.Get(legacyParamsKey))
 	require.Nil(t, rateLimitStore.Get(pendingSendKey))
 	require.Nil(t, rateLimitStore.Get(pendingReceiveKey))
 	require.Equal(t, []byte("preserved"), rateLimitStore.Get(rateLimitKey))


### PR DESCRIPTION
## Effects

- [ ] Soft update
- [ ] Breaking change
- [x] Chain fork related

<!-- If internal PR & if it is needed to check from a specific person, please mention. Or you may delete it  -->
## Major Reviewer
@yoosah 

<!-- List them -->

## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
exception handling for legacy parastore
<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
