### PR TITLE
fix: avoid initializing finalize block state during app startup

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -397,7 +397,7 @@ func NewXplaApp(
 			ChainID: app.ChainID(),
 		}))
 
-		ctx := app.BaseApp.NewNextBlockContext(tmproto.Header{})
+		ctx := app.NewContextLegacy(true, tmproto.Header{})
 
 		if err := app.WasmKeeper.InitializePinnedCodes(ctx); err != nil {
 			panic(fmt.Sprintf("WasmKeeper failed initialize pinned codes %s", err))

--- a/cmd/xplad/cmd/root.go
+++ b/cmd/xplad/cmd/root.go
@@ -229,6 +229,7 @@ func initRootCmd(rootCmd *cobra.Command,
 	)
 
 	evmserver.AddCommands(rootCmd, evmserver.NewDefaultStartOptions(ac.newApp, xpla.DefaultNodeHome), ac.appExport, addModuleInitFlags)
+	rootCmd.AddCommand(server.ModuleHashByHeightQuery(sdkAppCreatorWrapper))
 
 	// add keybase, auxiliary RPC, query, and tx child commands
 	keysCmd := evmclient.KeyCommands(xpla.DefaultNodeHome, true)


### PR DESCRIPTION
## Effects

  - [x] Soft update
  - [ ] Breaking change
  - [ ] Chain fork related

  ## Background

  When a node restarted after an incomplete consensus WAL, CometBFT attempted to replay a block through `FinalizeBlock` without executing `ProcessProposal`.

  During application startup, `NewXplaApp` used:

  ```go
  app.BaseApp.NewNextBlockContext(tmproto.Header{})
```

  to initialize pinned Wasm codes.

  NewNextBlockContext is a test helper that also initializes BaseApp's finalizeBlockState. Because it was called with an empty header, the resulting SDK context
  had an empty chain ID.

  During block replay, BaseApp detected that finalizeBlockState already existed and did not recreate it using the actual block header. Native Cosmos transactions
  were therefore verified with an empty chain ID and failed signature verification:
```
  signature verification failed; please verify account number (...) and chain-id ()
```
  The valid transaction was rejected locally, causing the replayed application state and AppHash to diverge from the network state.

  ## Summary

  Replace NewNextBlockContext with NewContextLegacy when initializing pinned Wasm codes.

  ctx := app.NewContextLegacy(true, tmproto.Header{})

  This preserves pinned-code initialization while avoiding mutation of BaseApp's finalizeBlockState.

  The implementation also matches the initialization pattern currently used by upstream Wasmd.


  ## Checklist

  - [x] Backward compatible?
  - [x] Test enough in your local environment?
  - [ ] Add related test cases?