### PR TITLE
apply evm patch

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -79,7 +79,7 @@ import (
 	"github.com/xpladev/xpla/app/openapiconsole"
 	xplaappparams "github.com/xpladev/xpla/app/params"
 	"github.com/xpladev/xpla/app/upgrades"
-	v1_10 "github.com/xpladev/xpla/app/upgrades/v1_10"
+	v1_11 "github.com/xpladev/xpla/app/upgrades/v1_11"
 	"github.com/xpladev/xpla/docs"
 	ethermintsecp256k1 "github.com/xpladev/xpla/legacy/ethermint/crypto/ethsecp256k1"
 	ethermintenc "github.com/xpladev/xpla/legacy/ethermint/encoding/codec"
@@ -98,7 +98,7 @@ var (
 	DefaultNodeHome string
 
 	Upgrades = []upgrades.Upgrade{
-		v1_10.Upgrade,
+		v1_11.Upgrade,
 	}
 )
 

--- a/app/upgrades/v1_11/const.go
+++ b/app/upgrades/v1_11/const.go
@@ -1,4 +1,4 @@
-package v1_10
+package v1_11
 
 import (
 	store "cosmossdk.io/store/types"
@@ -6,9 +6,7 @@ import (
 	"github.com/xpladev/xpla/app/upgrades"
 )
 
-const (
-	UpgradeName = "v1_10"
-)
+const UpgradeName = "v1_11"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,

--- a/app/upgrades/v1_11/upgrades.go
+++ b/app/upgrades/v1_11/upgrades.go
@@ -1,4 +1,4 @@
-package v1_10
+package v1_11
 
 import (
 	"context"
@@ -12,15 +12,17 @@ import (
 	"github.com/xpladev/xpla/app/keepers"
 )
 
+// CreateUpgradeHandler creates the v1_11 upgrade handler. The EVM hotfix does
+// not change module consensus versions or store layouts, so the standard module
+// migrations are sufficient for this binary upgrade.
 func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
-	keepers *keepers.AppKeepers,
-	cdc codec.BinaryCodec,
+	_ *keepers.AppKeepers,
+	_ codec.BinaryCodec,
 ) upgradetypes.UpgradeHandler {
-	return func(c context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+	return func(c context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		ctx := sdk.UnwrapSDKContext(c)
 		return mm.RunMigrations(ctx, configurator, fromVM)
-
 	}
 }

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistersV111Upgrade(t *testing.T) {
+	require.Len(t, Upgrades, 1)
+
+	upgrade := Upgrades[0]
+	require.Equal(t, "v1_11", upgrade.UpgradeName)
+	require.NotNil(t, upgrade.CreateUpgradeHandler)
+	require.Empty(t, upgrade.StoreUpgrades.Added)
+	require.Empty(t, upgrade.StoreUpgrades.Renamed)
+	require.Empty(t, upgrade.StoreUpgrades.Deleted)
+}

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-metrics v0.5.4
+	github.com/holiman/uint256 v1.3.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.0
 	github.com/spf13/cast v1.10.0
@@ -171,7 +172,6 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
-	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/huandu/skiplist v1.2.1 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/iancoleman/orderedmap v0.3.0 // indirect
@@ -286,7 +286,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/xpladev/cosmos-sdk v0.53.6-xpla-2
 
 	// xpla features
-	github.com/cosmos/evm => github.com/xpladev/evm v0.6.0-xpla.2
+	github.com/cosmos/evm => github.com/DELIGHT-LABS/evm-priv-jul2026 v0.6.0-xpla.3-july-2026-hotfix
 
 	// xpla features
 	github.com/cosmos/ledger-cosmos-go => github.com/xpladev/ledger-cosmos-go v0.16.0-xpla.1

--- a/go.sum
+++ b/go.sum
@@ -659,6 +659,8 @@ github.com/CosmWasm/wasmd v0.60.6 h1:fHv//SyVv/L6SS33fxMC2JGAUxy3ZyUlIOb6U3vkJvo
 github.com/CosmWasm/wasmd v0.60.6/go.mod h1:2Fs7Y8CEvtgjv5moPdOGLbZ6Vv49bypD5xu3DY0s4Hc=
 github.com/CosmWasm/wasmvm/v2 v2.3.2 h1:LO6+G9iG3Hg6EezxfMWX5TMx6a5DbuKGwZv6BSdtXfA=
 github.com/CosmWasm/wasmvm/v2 v2.3.2/go.mod h1:RzLlMwFRLaTwPM0DdHFA0m/APT5muKjU6t3ZxCrpXJ0=
+github.com/DELIGHT-LABS/evm-priv-jul2026 v0.6.0-xpla.3-july-2026-hotfix h1:zfI5rRk1k9crVJ4t8pZLKMtVTGFuk/0NINtPLkEWuCo=
+github.com/DELIGHT-LABS/evm-priv-jul2026 v0.6.0-xpla.3-july-2026-hotfix/go.mod h1:QnaJDtxqon2mywiYqxM8VwW8FKeFazi0au0qzVpFAG8=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -1726,8 +1728,6 @@ github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xpladev/cosmos-sdk v0.53.6-xpla-2 h1:6/ffVxMEIGJGqsDVF8fyRuVIaZ78Ftuo3iZvHAvAlcU=
 github.com/xpladev/cosmos-sdk v0.53.6-xpla-2/go.mod h1:N6YuprhAabInbT3YGumGDKONbvPX5dNro7RjHvkQoKE=
-github.com/xpladev/evm v0.6.0-xpla.2 h1:aoz5qAZYm1u2OJuO25CtwNKbQmFW8njBNQ2sP5PeRd4=
-github.com/xpladev/evm v0.6.0-xpla.2/go.mod h1:QnaJDtxqon2mywiYqxM8VwW8FKeFazi0au0qzVpFAG8=
 github.com/xpladev/go-ethereum v1.16.2-xpla-evm h1:kelMWZ91b/rfeMnIkk57w4rPSPm9wHlChFocIU1oIdU=
 github.com/xpladev/go-ethereum v1.16.2-xpla-evm/go.mod h1:X5CIOyo8SuK1Q5GnaEizQVLHT/DfsiGWuNeVdQcEMNA=
 github.com/xpladev/ledger-cosmos-go v0.16.0-xpla.1 h1:0sIH6/K1pE+75byzNDE3BoQ9gdl3KCfjeaAS6DSjnUg=


### PR DESCRIPTION
## Effects

- [ ] Soft update
- [x] Breaking change
- [x] Chain fork related

## Major Reviewer

@nowooj 

## Background

Apply the July Cosmos EVM hotfix security reason.

## Summary

- Update Cosmos EVM to `v0.6.0-xpla.3-july-2026-hotfix`.
- Add the `v1_11` software upgrade handler.
- Keep store layouts unchanged and run standard module migrations.
- Add upgrade registration tests.

## Checklist

- [ ] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?